### PR TITLE
debug changes for running mongo in stone soup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN set -eux; \
 	mkdir -p /data/db /data/configdb; \
 	chown -R mongod:mongod /data/db /data/configdb
 
+RUN chmod -R 777  /data/db 
+RUN chmod -R 777  /data/configdb
+
 RUN dnf -y install npm jq mongodb-org && dnf localinstall -y http://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/numactl-2.0.12-13.el8.x86_64.rpm https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/numactl-libs-2.0.12-13.el8.x86_64.rpm && dnf clean all && npm install mongodb && rm -rf /var/lib/mongo && mv /etc/mongod.conf /etc/mongod.conf.orig
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,21 @@
+schemaVersion: 2.2.0
+metadata:
+  name: build-mongo-from-source
+  projectType: container
+  language: container
+  attributes:
+    alpha.dockerimage-port: 27017
+  version: 1.0.0
+  provider: Red Hat  
+components:
+  - name: outerloop-build
+    image:
+      imageName: build-mongo-from-source
+      dockerfile:
+        uri: Dockerfile
+        buildContext: .
+        rootRequired: false 
+commands:
+  - id: build-image
+    apply:
+      component: outerloop-build

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,8 +3,7 @@
 # This is the entrypoint for the docker container
 # this will initialize mongo and start the server
 # and keep it running
-
-set -e
+ 
 
 # Set default arguments
 : ${MONGO_DATA_DIR:=/data/db}
@@ -13,17 +12,23 @@ set -e
 if [ -z "$(ls -A ${MONGO_DATA_DIR}/journal)" ]; then
 	echo "=> An empty or uninitialized MongoDB volume is detected in $MONGO_DATA_DIR"
 	echo "=> Installing MongoDB ..."
-	"$MONGO_HOME/bin/mongod" --quiet --dbpath "$MONGO_DATA_DIR" --logpath /dev/null --bind_ip_all --fork
+	"$MONGO_HOME/bin/mongod"  --dbpath "$MONGO_DATA_DIR" --bind_ip_all --fork
 	# Create the database pacman using a javascript file
 	echo "=> Creating pacman database ..."
 	mongosh --host localhost:27017 --authenticationDatabase admin --norc --file /usr/local/bin/create_pacman_db.js
+
+	echo "Killing the silent daemon and falling to a full logging one"
+	mongod --dbpath "$MONGO_DATA_DIR"--shutdown
 	echo "=> Done!"
 else
 	echo "=> Using an existing volume of MongoDB"
 fi
 
 # Start MongoDB
-echo "=> Starting MongoDB ..."
-exec "$MONGO_HOME/bin/mongod" --quiet --dbpath "$MONGO_DATA_DIR" --logpath /dev/null --bind_ip_all $CMDARG
+echo "=> Starting MongoDB in full logging mode ..."
+#exec "$MONGO_HOME/bin/mongod" --quiet --dbpath "$MONGO_DATA_DIR" --logpath /dev/null --bind_ip_all $CMDARG
+exec "$MONGO_HOME/bin/mongod"  --dbpath "$MONGO_DATA_DIR"   --bind_ip_all $CMDARG
+
 
 exec "$@"
+ 


### PR DESCRIPTION
- added a devfile, not needed but helps with default port for mongo
- permission on files don't match, for now 777 mode
- kill existing mongo in Creating pacman path for fall through case.